### PR TITLE
Fixed allocateLogger method behaviour.

### DIFF
--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -64,7 +64,7 @@ trait LoggerTrait
     {
         $container = ContainerScope::getContainer();
         if (empty($container) || !$container->has(LogsInterface::class)) {
-            return new NullLogger();
+            return $this->logger ?? new NullLogger();
         }
 
         //We are using class name as log channel (name) by default

--- a/tests/Logger/TraitTest.php
+++ b/tests/Logger/TraitTest.php
@@ -63,7 +63,7 @@ class TraitTest extends TestCase
         $container = new Container();
         $container->bind(LogsInterface::class, $logs);
 
-        ContainerScope::runScope($container, function () use ($logsInterfaceLogger) : void {
+        ContainerScope::runScope($container, function () use ($logsInterfaceLogger): void {
             $this->assertEquals($logsInterfaceLogger, $this->getLogger());
         });
     }
@@ -93,12 +93,12 @@ class TraitTest extends TestCase
         $container = new Container();
         $container->bind(LogsInterface::class, $logs);
 
-        ContainerScope::runScope($container, function () use ($logsInterfaceLogger) : void {
+        ContainerScope::runScope($container, function () use ($logsInterfaceLogger): void {
             $this->assertEquals($logsInterfaceLogger, $this->getLogger('test-channel'));
         });
     }
 
-    public function testGetsLoggerWhenChannelPassedAndLoggerSetButContainerDoesNotExists()
+    public function testGetsLoggerWhenChannelPassedAndLoggerSetButContainerDoesNotExists(): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->setLogger($logger);
@@ -106,13 +106,13 @@ class TraitTest extends TestCase
         $this->assertEquals($logger, $this->getLogger('test-channel'));
     }
 
-    public function testGetsLoggerWhenChannelPassedAndLoggerSetAndContainerExistsButContainerDoesNotHaveLogsInterface()
+    public function testGetsLoggerWhenChannelPassedAndLoggerSetAndContainerExistsButContainerDoesNotHaveLogsInterface(): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->setLogger($logger);
         $container = new Container();
 
-        ContainerScope::runScope($container, function () use ($logger) : void {
+        ContainerScope::runScope($container, function () use ($logger): void {
             $this->assertEquals($logger, $this->getLogger('test-channel'));
         });
     }

--- a/tests/Logger/TraitTest.php
+++ b/tests/Logger/TraitTest.php
@@ -106,7 +106,7 @@ class TraitTest extends TestCase
         $this->assertEquals($logger, $this->getLogger('test-channel'));
     }
 
-    public function testGetsLoggerWhenChannelPassedAndLoggerSetAndContainerExistsButContainerDoesNotHaveLogsInterface(): void
+    public function testGetsLoggerWhenChannelPassedAndLoggerSetAndContainerExistsButItDoesNotHaveLogsInterface(): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->setLogger($logger);

--- a/tests/Logger/TraitTest.php
+++ b/tests/Logger/TraitTest.php
@@ -13,6 +13,7 @@ namespace Spiral\Logger\Tests;
 
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Spiral\Core\Container;
 use Spiral\Core\ContainerScope;
@@ -42,18 +43,77 @@ class TraitTest extends TestCase
         $this->assertSame($logger, $this->getLogger());
     }
 
-    public function testScope(): void
+    public function testGetsLoggerWhenChannelNotPassedAndContainerExistsButItDoesNotHaveLogsInterface(): void
     {
+        $container = new Container();
+
+        ContainerScope::runScope($container, function (): void {
+            $this->assertInstanceOf(NullLogger::class, $this->getLogger());
+        });
+    }
+
+    public function testGetsLoggerWhenChannelNotPassedAndContainerExistsAndLogsInterfaceHasLogger(): void
+    {
+        $logsInterfaceLogger = new NullLogger();
         $logs = m::mock(LogsInterface::class);
         $logs->shouldReceive('getLogger')
-            ->with(self::class)
-            ->andReturn(new NullLogger());
+            ->with(static::class)
+            ->andReturn($logsInterfaceLogger);
 
         $container = new Container();
         $container->bind(LogsInterface::class, $logs);
 
+        ContainerScope::runScope($container, function () use($logsInterfaceLogger): void {
+            $this->assertEquals($logsInterfaceLogger, $this->getLogger());
+        });
+    }
+
+    public function testGetsLoggerWhenChannelPassedAndContainerDoesNotExist(): void
+    {
+        $this->assertInstanceOf(NullLogger::class, $this->getLogger('test-channel'));
+    }
+
+    public function testGetsLoggerWhenChannelPassedAndContainerExistsButItDoesNotHaveLogsInterface(): void
+    {
+        $container = new Container();
+
         ContainerScope::runScope($container, function (): void {
-            $this->assertInstanceOf(NullLogger::class, $this->getLogger());
+            $this->assertInstanceOf(NullLogger::class, $this->getLogger('test-channel'));
+        });
+    }
+
+    public function testGetsLoggerWhenChannelPassedAndContainerExistsAndLogsInterfaceHasLogger(): void
+    {
+        $logsInterfaceLogger = new NullLogger();
+        $logs = m::mock(LogsInterface::class);
+        $logs->shouldReceive('getLogger')
+            ->with('test-channel')
+            ->andReturn($logsInterfaceLogger);
+
+        $container = new Container();
+        $container->bind(LogsInterface::class, $logs);
+
+        ContainerScope::runScope($container, function () use($logsInterfaceLogger): void {
+            $this->assertEquals($logsInterfaceLogger, $this->getLogger('test-channel'));
+        });
+    }
+
+    public function testGetsLoggerWhenChannelPassedAndLoggerSetButContainerDoesNotExists()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->setLogger($logger);
+
+        $this->assertEquals($logger, $this->getLogger('test-channel'));
+    }
+
+    public function testGetsLoggerWhenChannelPassedAndLoggerSetAndContainerExistsButContainerDoesNotHaveLogsInterface()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->setLogger($logger);
+        $container = new Container();
+
+        ContainerScope::runScope($container, function () use($logger): void {
+            $this->assertEquals($logger, $this->getLogger('test-channel'));
         });
     }
 }

--- a/tests/Logger/TraitTest.php
+++ b/tests/Logger/TraitTest.php
@@ -63,7 +63,7 @@ class TraitTest extends TestCase
         $container = new Container();
         $container->bind(LogsInterface::class, $logs);
 
-        ContainerScope::runScope($container, function () use($logsInterfaceLogger): void {
+        ContainerScope::runScope($container, function () use ($logsInterfaceLogger) : void {
             $this->assertEquals($logsInterfaceLogger, $this->getLogger());
         });
     }
@@ -93,7 +93,7 @@ class TraitTest extends TestCase
         $container = new Container();
         $container->bind(LogsInterface::class, $logs);
 
-        ContainerScope::runScope($container, function () use($logsInterfaceLogger): void {
+        ContainerScope::runScope($container, function () use ($logsInterfaceLogger) : void {
             $this->assertEquals($logsInterfaceLogger, $this->getLogger('test-channel'));
         });
     }
@@ -112,7 +112,7 @@ class TraitTest extends TestCase
         $this->setLogger($logger);
         $container = new Container();
 
-        ContainerScope::runScope($container, function () use($logger): void {
+        ContainerScope::runScope($container, function () use ($logger) : void {
             $this->assertEquals($logger, $this->getLogger('test-channel'));
         });
     }


### PR DESCRIPTION
- Fixed allocateLogger method behaviour.
When getLogger received channel it used NullLoger instead of existing logger.
See https://github.com/cycle/orm/issues/110

- Covered different behaviours with unit tests